### PR TITLE
Fixed error 400 incorrect postal code

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Example:
         width: 54.234,
         height: 12
       },
-      destinationPostalCode: 'H0H0H0'
+      destinationPostalCode: 'K1A0A6'
     }, function(err, rates) {
       console.log(err,rates);
     });

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Start by setting up some defaults, these can be changed any time before calling 
 Finding Rates for a Package
 ---------------------------
 
-Call the `getRatesDomestic` function and pass an object containing at least a weight and destinationPostalCode.
+Call the `getRates` function and pass an object containing at least a weight and either destinationPostalCode, destinationZipCode or destinationCountryCode.
 Optionally you can send along package dimensions (length is the longest side, width the next longest, and height the
 smallest of the sides). Weight is measured in KiloGrams and dimensions are in CentiMeters.
 
@@ -44,7 +44,7 @@ Postal codes should always be all caps with no spaces.
 
 Example:
 
-    CanadaPost.getRatesDomestic({
+    CanadaPost.getRates({
       weight: 10, // kg
       dimensions: {
         length: 64.5,
@@ -56,6 +56,11 @@ Example:
       console.log(err,rates);
     });
 
+Choose which destination to ship to by specifying either:
+
+- destinationPostalCode - Ship to Canada
+- destinationZipCode - Ship to the United States
+- destinationCountryCode - ship to any other country. Use the 2 character country code.
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Getting Started
 
 The easiest way to grab the module is through `npm`:
 
-    npm install canadapost
+    npm install node-canadapost-v3
 
 
 Pass your username, password and customer ID for the Canada Post API when requiring the library:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-node-canadapost
-===============
+node-canadapost-international
+=============================
 
 A node module for integrating with Canada Post's shipping API
 
-This module is early in its development and has limited functionality. Feel free to contribute.
+This module currently only supports Rates. Feel free to contribute.
 
 
 Getting Started
@@ -11,7 +11,7 @@ Getting Started
 
 The easiest way to grab the module is through `npm`:
 
-    npm install node-canadapost-v3
+    npm install node-canadapost-international
 
 
 Pass your username, password and customer ID for the Canada Post API when requiring the library:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The easiest way to grab the module is through `npm`:
 
 Pass your username, password and customer ID for the Canada Post API when requiring the library:
 
-    var CanadaPost = require('canadapost')('<username>', '<password>', '<customerId>');
+    var CanadaPost = require('node-canadapost-international')('<username>', '<password>', '<customerId>');
 
 The module uses your NODE_ENV environment variable to determine if it's authenticating against their
 production or development servers, if NODE_ENV is set to anything other than 'production' it will assume

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,7 +105,7 @@ CanadaPost.prototype.getRates = function(params, callback) {
     parseXML(body, function(err, result) {
       if (err) return callback(err);
 
-      if (response.statusCode === 403) {
+      if (response.statusCode !== 200) {
         return callback(new Error(result.messages.message[0].description[0]));
       }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,8 +24,8 @@ var CanadaPost = function CanadaPost(apiUsername, apiPassword, customerNumber) {
   }
   this.headers = {
     'Authorization': 'Basic ' + new Buffer(this.username + ':' + this.password).toString('base64'),
-    'Content-Type': 'application/vnd.cpc.ship.rate-v2+xml',
-    'Accept': 'application/vnd.cpc.ship.rate-v2+xml'
+    'Content-Type': 'application/vnd.cpc.ship.rate-v3+xml',
+    'Accept': 'application/vnd.cpc.ship.rate-v3+xml'
   };
 };
 module.exports = function(apiUsername, apiPassword, customerNumber) {
@@ -57,7 +57,7 @@ CanadaPost.prototype.useContract = function(useContract) {
 CanadaPost.prototype.getRatesDomestic = function(params, callback) {
 
   var xml = builder.create('mailing-scenario', { 'version': '1.0', 'encoding': 'UTF-8' })
-    .att('xmlns', 'http://www.canadapost.ca/ws/ship/rate-v2');
+    .att('xmlns', 'http://www.canadapost.ca/ws/ship/rate-v3');
 
   xml.ele('origin-postal-code', this.originPostalCode).up()
     .ele('destination')

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,7 @@ CanadaPost.prototype.getRates = function(params, callback) {
     destination.ele('united-states')
       .ele('zip-code', params.destinationZipCode).up().up().up();
   } else if (params.destinationCountryCode) {
-    destination.ele('domestic')
+    destination.ele('international')
       .ele('country-code', params.destinationCountryCode).up().up().up();
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,9 @@ CanadaPost.prototype.useContract = function(useContract) {
  * Finds domestic shipping rates from the Canada Post API
  *
  * @param {json} params Shipment Information
- *  @param {String} params.destinationPostalCode Postal code where package is being shipped to (no spaces, all caps)
+ *  @param {String} params.destinationPostalCode - Canada: Postal code where package is being shipped to (no spaces, all caps)
+ *  @param {String} params.destinationZipCode - US: Zip code where package is being shipped to (no spaces, all caps)
+ *  @param {String} params.destinationCountryCode - International: Country code where package is being shipped to (no spaces, all caps)
  *  @param {Integer} params.weight Weight in kilograms
  *  @param {json} [params.dimensions] Package dimensions in centimeters
  *    @param {Number} params.dimensions.length Longest side in cm (3.0 to 999.9)
@@ -54,15 +56,24 @@ CanadaPost.prototype.useContract = function(useContract) {
  *    @param {Number} params.dimensions.height Third longest side in cm (3.0 to 999.9)
  * @param callback
  * ==================================================================================================== */
-CanadaPost.prototype.getRatesDomestic = function(params, callback) {
+CanadaPost.prototype.getRates = function(params, callback) {
 
   var xml = builder.create('mailing-scenario', { 'version': '1.0', 'encoding': 'UTF-8' })
     .att('xmlns', 'http://www.canadapost.ca/ws/ship/rate-v3');
 
-  xml.ele('origin-postal-code', this.originPostalCode).up()
-    .ele('destination')
-      .ele('domestic')
-        .ele('postal-code', params.destinationPostalCode).up().up().up();
+  var destination = xml.ele('origin-postal-code', this.originPostalCode).up()
+    .ele('destination');
+
+  if (params.destinationPostalCode) {
+    destination.ele('domestic')
+      .ele('postal-code', params.destinationPostalCode).up().up().up();
+  } else if (params.destinationZipCode) {
+    destination.ele('united-states')
+      .ele('zip-code', params.destinationZipCode).up().up().up();
+  } else if (params.destinationCountryCode) {
+    destination.ele('domestic')
+      .ele('country-code', params.destinationCountryCode).up().up().up();
+  }
 
   if (this.contract) {
     xml.ele('customer-number', this.customerNumber.toString()).up();

--- a/lib/index.js
+++ b/lib/index.js
@@ -128,7 +128,7 @@ CanadaPost.prototype.getRates = function(params, callback) {
           outQuote.serviceStandard.amDelivery = (serviceStandard['am-delivery'][0] == 'true');
           outQuote.serviceStandard.guaranteedDelivery = (serviceStandard['guaranteed-delivery'][0] == 'true');
           outQuote.serviceStandard.expectedTransitTime = serviceStandard['expected-transit-time'] ? parseInt(serviceStandard['expected-transit-time'][0]) : null;
-          outQuote.serviceStandard.expectedDeliveryDate = moment(serviceStandard['expected-delivery-date'][0], 'YYYY-MM-DD').unix();
+          outQuote.serviceStandard.expectedDeliveryDate = serviceStandard['expected-transit-time'] ? moment(serviceStandard['expected-delivery-date'][0], 'YYYY-MM-DD').unix() : null;
 
           r.push(outQuote);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -124,10 +124,11 @@ CanadaPost.prototype.getRates = function(params, callback) {
           outQuote.price.pst = parseFloat(cq['price-details'][0].taxes[0].pst[0]['_'] || 0);
           outQuote.price.hst = parseFloat(cq['price-details'][0].taxes[0].hst[0]['_'] || 0);
           outQuote.price.total = parseFloat(cq['price-details'][0].due[0]);
-          outQuote.serviceStandard.amDelivery = (cq['service-standard'][0]['am-delivery'][0] == 'true');
-          outQuote.serviceStandard.guaranteedDelivery = (cq['service-standard'][0]['guaranteed-delivery'][0] == 'true');
-          outQuote.serviceStandard.expectedTransitTime = parseInt(cq['service-standard'][0]['expected-transit-time'][0]);
-          outQuote.serviceStandard.expectedDeliveryDate = moment(cq['service-standard'][0]['expected-delivery-date'][0], 'YYYY-MM-DD').unix();
+          var serviceStandard = cq['service-standard'][0];
+          outQuote.serviceStandard.amDelivery = (serviceStandard['am-delivery'][0] == 'true');
+          outQuote.serviceStandard.guaranteedDelivery = (serviceStandard['guaranteed-delivery'][0] == 'true');
+          outQuote.serviceStandard.expectedTransitTime = serviceStandard['expected-transit-time'] ? parseInt(serviceStandard['expected-transit-time'][0]) : null;
+          outQuote.serviceStandard.expectedDeliveryDate = moment(serviceStandard['expected-delivery-date'][0], 'YYYY-MM-DD').unix();
 
           r.push(outQuote);
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-canadapost-v3",
   "preferGlobal": false,
-  "version": "0.0.7",
+  "version": "0.0.8",
   "author": "Brent Luehr <brent@nerdcon.com>",
   "description": "A wrapper for the Canada Post API to save you time",
   "contributors": [],

--- a/package.json
+++ b/package.json
@@ -1,21 +1,22 @@
 {
-  "name": "node-canadapost-v3",
+  "name": "node-canadapost-international",
   "preferGlobal": false,
-  "version": "0.0.9",
+  "version": "0.0.10",
   "author": "Brent Luehr <brent@nerdcon.com>",
-  "description": "A wrapper for the Canada Post API to save you time",
-  "contributors": [],
+  "description": "A wrapper for the Canada Post API for dmoestic, US and international rates",
+  "contributors": ["Daniel Flippance <danielflippance@hotmail.com>"],
   "scripts": {},
   "main": "./lib",
   "repository": {
     "type": "git",
-    "url": "https://github.com/danielflippance/node-canadapost.git"
+    "url": "https://github.com/danielflippance/node-canadapost-international.git"
   },
   "keywords": [
     "canada",
     "post",
     "shipping",
-    "postage"
+    "postage",
+    "rates"
   ],
   "dependencies": {
     "request": "~2.21.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "canadapost",
+  "name": "node-canadapost-v3",
   "preferGlobal": false,
-  "version": "0.0.4",
+  "version": "0.0.5",
   "author": "Brent Luehr <brent@nerdcon.com>",
   "description": "A wrapper for the Canada Post API to save you time",
   "contributors": [],
@@ -9,7 +9,7 @@
   "main": "./lib",
   "repository": {
     "type": "git",
-    "url": "https://github.com/seratonik/node-canadapost.git"
+    "url": "https://github.com/danielflippance/node-canadapost.git"
   },
   "keywords": [
     "canada",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-canadapost-v3",
   "preferGlobal": false,
-  "version": "0.0.5",
+  "version": "0.0.6",
   "author": "Brent Luehr <brent@nerdcon.com>",
   "description": "A wrapper for the Canada Post API to save you time",
   "contributors": [],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-canadapost-v3",
   "preferGlobal": false,
-  "version": "0.0.6",
+  "version": "0.0.7",
   "author": "Brent Luehr <brent@nerdcon.com>",
   "description": "A wrapper for the Canada Post API to save you time",
   "contributors": [],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-canadapost-international",
   "preferGlobal": false,
-  "version": "0.0.11",
+  "version": "0.0.12",
   "author": "Brent Luehr <brent@nerdcon.com>",
   "description": "A wrapper for the Canada Post API for dmoestic, US and international rates",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-canadapost-v3",
   "preferGlobal": false,
-  "version": "0.0.8",
+  "version": "0.0.9",
   "author": "Brent Luehr <brent@nerdcon.com>",
   "description": "A wrapper for the Canada Post API to save you time",
   "contributors": [],

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "node-canadapost-international",
   "preferGlobal": false,
-  "version": "0.0.10",
+  "version": "0.0.11",
   "author": "Brent Luehr <brent@nerdcon.com>",
   "description": "A wrapper for the Canada Post API for dmoestic, US and international rates",
-  "contributors": ["Daniel Flippance <danielflippance@hotmail.com>"],
+  "contributors": [
+    "Daniel Flippance <danielflippance@hotmail.com>"
+  ],
   "scripts": {},
   "main": "./lib",
   "repository": {


### PR DESCRIPTION
Readme example provides santa's address but it's no longer valid and throws a 400 error. Fixed the condition so that the callback will display 400 errors. Changed readme address to parliament hill.